### PR TITLE
warning instead of assert in Sampler

### DIFF
--- a/src/audio/object/sampler.cpp
+++ b/src/audio/object/sampler.cpp
@@ -124,11 +124,12 @@ namespace nap
             if (samplerEntryIndex > mSamplerEntries.size())
                 return nullptr;
 
-            int busyVoiceCount = mPolyphonicInstance->getBusyVoiceCount();
-            Logger::info("Busy voice count %i", busyVoiceCount);
-            
             auto voice = mPolyphonicInstance->findFreeVoice();
-            assert(voice != nullptr);
+			if (voice == nullptr)
+			{
+				Logger::warn("Failed to acquire free voice");
+				return nullptr;
+			}
             auto bufferLooper = voice->getObject<BufferLooperInstance>("BufferLooper");
             auto& envelope = voice->getEnvelope();
 


### PR DESCRIPTION
Instead of asserting when no free voice is found for a new play event a warning is issued.